### PR TITLE
Add checkbox for each index with a custom analyzer.

### DIFF
--- a/_site/js/controllers/AnalyzerCtrl.js
+++ b/_site/js/controllers/AnalyzerCtrl.js
@@ -132,6 +132,8 @@ function AnalyzerCtrl($scope, $http, Analyzer, Data){
     function updateCustomAnalyzers(){
 
         for (index in $scope.analyzer.customAnalyzers){
+            if ( ! $scope.analyzer.customAnalyzers[index].enable )
+              continue;
 
             //Make sure this index has some analyzer defined
             if (typeof $scope.analyzer.customAnalyzers[index].index.analysis !== "undefined"

--- a/_site/views/analyzers.html
+++ b/_site/views/analyzers.html
@@ -30,7 +30,7 @@
             <table class="table table-bordered" style="width:100%" ng-repeat="(index, val) in analyzer.customAnalyzers">
                 <thead>
                 <tr>
-                    <td style="width:100px">Index: {{index}}</td>
+                    <td style="width:100px"><input type="checkbox" ng-model="val.enable" style="margin:2px">Index: {{index}}</td>
                     <td>Analyzed Text</td>
                 </tr>
                 </thead>


### PR DESCRIPTION
On clusters with 20+ indices the analyzers get very slow when you try and analyze across all analyzers in the cluster.

By default this change disables querying the analyzer until the user selects it.

Could probably use further refinement by sorting the indices based on which ones are enabled, and maybe being able to disable the default analyzers also.
