### PR TITLE
Clear indices list before reload

### DIFF
--- a/_site/js/controllers/DropdownCtrl.js
+++ b/_site/js/controllers/DropdownCtrl.js
@@ -13,6 +13,9 @@ function DropdownCtrl($scope, $http, Data, pubsub) {
     $scope.loadMappings = function(){
       var path = $scope.data.host + "/_mapping";
       $http.get(path).then(function(response){
+          if($scope.indices && $scope.indices.length > 0){
+              $scope.indicies.length = 0;
+          }
           $scope.data.mapping = response.data;
 
           for (i in response.data){


### PR DESCRIPTION
This PR provides a fix for the issue that the index list is not cleared when mappings are loaded from a different host.
