### PR TITLE
update the query page to work with 1.0.x

### DIFF
--- a/_site/js/controllers/DropdownCtrl.js
+++ b/_site/js/controllers/DropdownCtrl.js
@@ -22,7 +22,7 @@ function DropdownCtrl($scope, $http, Data, pubsub) {
 
               $scope.indices.push(i);
               $scope.types[i] = [];
-              for (j in response.data[i]){
+              for (j in response.data[i].mappings){
 
                   $scope.types[i].push(j);
               }


### PR DESCRIPTION
get mapping response have been changed from something like
{
    "index_name" : {
        "mapping_name": {
        [...]
        }
    }
}
to
{
    "index_name" : {
        "mappings : {
            "mapping_name": {
            [...]
            }
        }
    }
}
