### PR TITLE
Add plugin description

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,4 @@
+description=elasticsearch-inquisitor - site plugin for Elasticsearch to help understand and debug queries.
+version=0.1.2
+site=true
+name=elasticsearch-inquisitor


### PR DESCRIPTION
This will prevent ` ERROR: Could not find plugin descriptor 'plugin-descriptor.properties' in plugin zip` during installation
