### PR TITLE
Improve the default host value

### DIFF
--- a/_site/js/controllers/NavbarCtrl.js
+++ b/_site/js/controllers/NavbarCtrl.js
@@ -2,8 +2,6 @@
 function NavbarCtrl($scope, $rootScope, $route, $location, Data) {
     $scope.data = Data;
 
-    $scope.data.host = window.location.protocol + '//' + window.location.host;
-
     $scope.isActive = function(route) {
 
         var path = $location.path();


### PR DESCRIPTION
- add support for passing the ES host in a query string parameter, allowing for a better experience for standalone deployments (i.e. when running this site by pointing a webserver to the `_site` folder rather than using ES to run this webserver for a site plugin)
- use the current location only when the site runs as an ES site plugin